### PR TITLE
feat: Add training details view and fix API route

### DIFF
--- a/app/api/lora/v2/train/[id]/route.ts
+++ b/app/api/lora/v2/train/[id]/route.ts
@@ -1,0 +1,24 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { trainingStatuses } from "@/lib/training-store"
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const trainingId = params.id
+    const status = trainingStatuses.get(trainingId)
+
+    if (!status) {
+      return NextResponse.json({ error: "Training not found" }, { status: 404 })
+    }
+
+    return NextResponse.json(status)
+  } catch (error) {
+    console.error("Failed to get training status:", error)
+    return NextResponse.json(
+      { error: "Failed to get training status" },
+      { status: 500 }
+    )
+  }
+}

--- a/lib/training-store.ts
+++ b/lib/training-store.ts
@@ -1,0 +1,15 @@
+export interface TrainingStatus {
+  id: string;
+  status: "preparing" | "training" | "completed" | "failed";
+  progress: number;
+  currentStep: number;
+  totalSteps: number;
+  logs: string[];
+  error?: string;
+  startTime: string;
+  endTime?: string;
+  outputPath?: string;
+}
+
+export const trainingStatuses = new Map<string, TrainingStatus>();
+export const activeProcesses = new Map<string, any>();


### PR DESCRIPTION
This commit introduces a new feature to view the details of a LoRA training session. It also refactors the backend API for fetching training statuses to be more robust.

- A new dynamic API route `/api/lora/v2/train/[id]` has been created to fetch the status of a single training session.
- The in-memory training store has been refactored into a separate `lib/training-store.ts` file to allow for sharing between API routes.
- The frontend has been updated with a "Details" button on the training status card, which opens a dialog with the training logs.

This change is intended to fix a 404 error that was occurring when trying to fetch the status of a training session.